### PR TITLE
Update version and enable battle edits

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,7 +1,7 @@
 from WTStatTracker import WTStatTracker
 from src.version_manager import VersionManager
 
-CURRENT_VERSION = "0.4.6"
+CURRENT_VERSION = "0.4.7"
 REPO_OWNER = "ResizeValue"
 REPO_NAME = "WT-stats"
 


### PR DESCRIPTION
Updates version from 0.4.6 to 0.4.7.
Centralizes filter values using predefined nation and battle type lists. Removes redundant refreshing and binds double-click event for inline battle editing.